### PR TITLE
Extend evmc interface with step-n functionality

### DIFF
--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -49,6 +49,41 @@ static struct evmc_result execute_wrapper(struct evmc_vm* vm,
 	struct evmc_host_context* context = (struct evmc_host_context*)context_index;
 	return evmc_execute(vm, &evmc_go_host, context, rev, &msg, code_hash, code, code_size);
 }
+
+static struct evmc_step_result step_n_wrapper(struct evmc_vm_steppable* vm,
+                                              uintptr_t context_index,
+                                              enum evmc_revision rev,
+                                              enum evmc_call_kind kind,
+                                              uint32_t flags,
+                                              int32_t depth,
+                                              int64_t gas,
+                                              const evmc_address* recipient,
+                                              const evmc_address* sender,
+                                              const uint8_t* input_data,
+                                              size_t input_size,
+                                              const evmc_uint256be* value,
+                                              const evmc_bytes32* code_hash,
+                                              const uint8_t* code,
+                                              size_t code_size,
+                                              enum evmc_step_status_code status,
+                                              uint64_t pc,
+                                              int64_t gas_refunds,
+                                              evmc_uint256be* stack,
+                                              size_t stack_size,
+                                              uint8_t* memory,
+                                              size_t memory_size,
+                                              int32_t steps)
+{
+    struct evmc_message msg = {
+        kind,    flags,      depth,      gas,    *recipient,
+        *sender, input_data, input_size, *value, {{0}},  // create2_salt: not required for execution
+        {{0}},                                           // code_address: not required for execution
+    };
+
+    struct evmc_host_context* context = (struct evmc_host_context*)context_index;
+    return evmc_step_n(vm, &evmc_go_host, context, rev, &msg, code_hash, code, code_size, status,
+                       pc, gas_refunds, stack, stack_size, memory, memory_size, steps);
+}
 */
 import "C"
 
@@ -137,6 +172,30 @@ func Load(filename string) (vm *VM, err error) {
 	return vm, err
 }
 
+type VMSteppable struct {
+	handle *C.struct_evmc_vm_steppable
+}
+
+func LoadSteppable(filename string) (vm *VMSteppable, err error) {
+	cfilename := C.CString(filename)
+	loaderErr := C.enum_evmc_loader_error_code(C.EVMC_LOADER_UNSPECIFIED_ERROR)
+	handle := C.evmc_load_and_create_steppable(cfilename, &loaderErr)
+	C.free(unsafe.Pointer(cfilename))
+
+	if loaderErr == C.EVMC_LOADER_SUCCESS {
+		vm = &VMSteppable{handle}
+	} else {
+		errMsg := C.evmc_last_error_msg()
+		if errMsg != nil {
+			err = fmt.Errorf("EVMC loading error: %s", C.GoString(errMsg))
+		} else {
+			err = fmt.Errorf("EVMC loading error %d", int(loaderErr))
+		}
+	}
+
+	return vm, err
+}
+
 func LoadAndConfigure(config string) (vm *VM, err error) {
 	cconfig := C.CString(config)
 	loaderErr := C.enum_evmc_loader_error_code(C.EVMC_LOADER_UNSPECIFIED_ERROR)
@@ -199,6 +258,14 @@ func (vm *VM) GetHandle() unsafe.Pointer {
 	return unsafe.Pointer(vm.handle)
 }
 
+func (vm *VMSteppable) GetHandle() unsafe.Pointer {
+	return unsafe.Pointer(vm.handle)
+}
+
+func (vm *VMSteppable) GetBaseHandle() unsafe.Pointer {
+	return unsafe.Pointer(vm.handle.vm)
+}
+
 type Parameters struct {
 	Context   HostContext
 	Revision  Revision
@@ -254,6 +321,105 @@ func (vm *VM) Execute(params Parameters) (res Result, err error) {
 
 	if result.release != nil {
 		C.evmc_release_result(&result)
+	}
+
+	return res, err
+}
+
+type StepStatus int32
+
+const (
+	Running  = StepStatus(C.EVMC_STEP_RUNNING)
+	Stopped  = StepStatus(C.EVMC_STEP_STOPPED)
+	Returned = StepStatus(C.EVMC_STEP_RETURNED)
+	Reverted = StepStatus(C.EVMC_STEP_REVERTED)
+	Failed   = StepStatus(C.EVMC_STEP_FAILED)
+)
+
+type StepParameters struct {
+	Context        HostContext
+	Revision       Revision
+	Kind           CallKind
+	Static         bool
+	Depth          int
+	Gas            int64
+	GasRefund      int64
+	Recipient      Address
+	Sender         Address
+	Input          []byte
+	Value          Hash
+	CodeHash       *Hash
+	Code           []byte
+	StepStatusCode StepStatus
+	Pc             uint64
+	Stack          []byte
+	Memory         []byte
+	NumSteps       int
+}
+
+type StepResult struct {
+	StepStatusCode StepStatus
+	StatusCode     Error
+	Revision       Revision
+	Pc             uint64
+	GasLeft        int64
+	GasRefund      int64
+	Output         []byte
+	Stack          []byte
+	Memory         []byte
+}
+
+func (vm *VMSteppable) StepN(params StepParameters) (res StepResult, err error) {
+	flags := C.uint32_t(0)
+	if params.Static {
+		flags |= C.EVMC_STATIC
+	}
+
+	ctxId := addHostContext(params.Context)
+	// FIXME: Clarify passing by pointer vs passing by value.
+	evmcRecipient := evmcAddress(params.Recipient)
+	evmcSender := evmcAddress(params.Sender)
+	evmcValue := evmcBytes32(params.Value)
+
+	var codeHash *C.evmc_bytes32
+	if params.CodeHash != nil {
+		hash := evmcBytes32(*params.CodeHash)
+		codeHash = &hash
+	}
+
+	stack := (*C.evmc_uint256be)(nil)
+	if len(params.Stack) > 0 {
+		stack = (*C.evmc_uint256be)(unsafe.Pointer(&params.Stack[0]))
+	}
+
+	memory := (*C.uint8_t)(nil)
+	if len(params.Memory) > 0 {
+		memory = (*C.uint8_t)(unsafe.Pointer(&params.Memory[0]))
+	}
+
+	result := C.step_n_wrapper(vm.handle, C.uintptr_t(ctxId),
+		uint32(params.Revision), C.enum_evmc_call_kind(params.Kind), flags,
+		C.int32_t(params.Depth), C.int64_t(params.Gas), &evmcRecipient,
+		&evmcSender, bytesPtr(params.Input), C.size_t(len(params.Input)), &evmcValue,
+		codeHash, bytesPtr(params.Code), C.size_t(len(params.Code)),
+		C.enum_evmc_step_status_code(params.StepStatusCode), C.uint64_t(params.Pc),
+		C.int64_t(params.GasRefund), stack, C.size_t(len(params.Stack)/32), memory,
+		C.size_t(len(params.Memory)), C.int32_t(params.NumSteps))
+
+	removeHostContext(ctxId)
+
+	res.StepStatusCode = StepStatus(result.step_status_code)
+	res.StatusCode = Error(result.status_code)
+	res.Revision = Revision(result.revision)
+	res.Pc = uint64(result.pc)
+	res.GasLeft = int64(result.gas_left)
+	res.GasRefund = int64(result.gas_refund)
+	res.Output = C.GoBytes(unsafe.Pointer(result.output_data), C.int(result.output_size))
+	res.Stack = C.GoBytes(unsafe.Pointer(result.stack), C.int(result.stack_size*32))
+	res.Memory = C.GoBytes(unsafe.Pointer(result.memory), C.int(result.memory_size))
+
+	if result.release != nil {
+		C.evmc_release_step_result(&result)
 	}
 
 	return res, err

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -366,6 +366,31 @@ enum evmc_status_code
     EVMC_OUT_OF_MEMORY = -3
 };
 
+/**
+ * The step status code.
+ *
+ * This represents a high-level summary of the execution status.
+ * In case of ::EVMC_STEP_FAILED a more detailed status code is provided by
+ * the ::evmc_step_result::status_code field.
+ */
+enum evmc_step_status_code
+{
+    /** Execution is still in progress. */
+    EVMC_STEP_RUNNING = 0,
+
+    /** Execution has halted successfully. */
+    EVMC_STEP_STOPPED = 1,
+
+    /** Execution has finished successfully. */
+    EVMC_STEP_RETURNED = 2,
+
+    /** Execution terminated with REVERT opcode. */
+    EVMC_STEP_REVERTED = 3,
+
+    /** Execution failed (for any reason). */
+    EVMC_STEP_FAILED = 4
+};
+
 /* Forward declaration. */
 struct evmc_result;
 
@@ -1125,6 +1150,203 @@ struct evmc_vm
      * If the VM does not support this feature the pointer can be NULL.
      */
     evmc_set_option_fn set_option;
+};
+
+/* Forward declaration. */
+struct evmc_step_result;
+
+/**
+ * Releases resources assigned to a stepping result.
+ *
+ * This function releases memory (and other resources, if any) assigned to the
+ * specified stepping result making the result object invalid.
+ *
+ * @param result  The stepping result which resources are to be released. The
+ *                result itself it not modified by this function, but becomes
+ *                invalid and user MUST discard it as well.
+ *                This MUST NOT be NULL.
+ *
+ * @note
+ * The result is passed by pointer to avoid (shallow) copy of the ::evmc_step_result
+ * struct. Think of this as the best possible C language approximation to
+ * passing objects by reference.
+ */
+typedef void (*evmc_release_step_result_fn)(const struct evmc_step_result* result);
+
+/** The EVM stepping result. */
+struct evmc_step_result
+{
+    /** The status code of the step. */
+    enum evmc_step_status_code step_status_code;
+
+    /** The execution status code.
+     *
+     * Not all states that the VM can be in can be represented by this field.
+     * Specifically if the VM is still running, or if the VM has returned.
+     * Those cases are represented by ::EVMC_STEP_RUNNING and ::EVMC_STEP_RETURNED in the
+     * evmc_step_result::step_status_code field.
+     */
+    enum evmc_status_code status_code;
+
+    /** The revision of the EVM specification used for the execution. */
+    enum evmc_revision revision;
+
+    /** The program counter after the execution. */
+    uint64_t pc;
+
+    /**
+     * The amount of gas left after the execution.
+     *
+     * If evmc_step_result::status_code is neither ::EVMC_SUCCESS nor ::EVMC_REVERT
+     * the value MUST be 0.
+     */
+    int64_t gas_left;
+
+    /**
+     * The refunded gas accumulated from this execution and its sub-calls.
+     *
+     * The transaction gas refund limit is not applied.
+     * If evmc_step_result::status_code is other than ::EVMC_SUCCESS the value MUST be 0.
+     */
+    int64_t gas_refund;
+
+    /**
+     * The reference to output data.
+     *
+     * The output contains data coming from RETURN opcode (iff evmc_step_result::status_code
+     * field is ::EVMC_SUCCESS) or from REVERT opcode.
+     *
+     * The memory containing the output data is owned by EVM and has to be
+     * freed with evmc_step_result::release().
+     *
+     * This pointer MAY be NULL.
+     * If evmc_step_result::output_size is 0 this pointer MUST NOT be dereferenced.
+     */
+    const uint8_t* output_data;
+
+    /**
+     * The size of the output data.
+     *
+     * If evmc_step_result::output_data is NULL this MUST be 0.
+     */
+    size_t output_size;
+
+    /** The stack after the execution. */
+    const evmc_uint256be* stack;
+
+    /** The number of items on the stack. */
+    size_t stack_size;
+
+    /** The memory after the execution. */
+    const uint8_t* memory;
+
+    /** The size of the memory. */
+    size_t memory_size;
+
+    /**
+     * The method releasing all resources associated with the step result object.
+     *
+     * This method (function pointer) is optional (MAY be NULL) and MAY be set
+     * by the VM implementation. If set it MUST be called by the user once to
+     * release memory and other resources associated with the result object.
+     * Once the resources are released the result object MUST NOT be used again.
+     *
+     * The suggested code pattern for releasing step results:
+     * @code
+     * struct evmc_step_result result = ...;
+     * if (result.release)
+     *     result.release(&result);
+     * @endcode
+     *
+     * @note
+     * It works similarly to C++ virtual destructor. Attaching the release
+     * function to the result itself allows VM composition.
+     */
+    evmc_release_step_result_fn release;
+};
+
+/* Forward declaration. */
+struct evmc_vm_steppable;
+
+/**
+ * Executes the given code using the input from the message for N steps.
+ *
+ * This function MAY be invoked multiple times for a single VM instance.
+ *
+ * @param vm          The VM instance. This argument MUST NOT be NULL.
+ * @param host        The Host interface. This argument MUST NOT be NULL unless
+ *                    the @p vm has the ::EVMC_CAPABILITY_PRECOMPILES capability.
+ * @param context     The opaque pointer to the Host execution context.
+ *                    This argument MAY be NULL. The VM MUST pass the same
+ *                    pointer to the methods of the @p host interface.
+ *                    The VM MUST NOT dereference the pointer.
+ * @param rev         The requested EVM specification revision.
+ * @param msg         The call parameters. See ::evmc_message. This argument MUST NOT be NULL.
+ * @param code_hash   The hash of the code to be executed. This argument MAY be NULL.
+ * @param code        The reference to the code to be executed. This argument MAY be NULL.
+ * @param code_size   The length of the code. If @p code is NULL this argument MUST be 0.
+ * @param status      The status code of the step.
+ * @param pc          The program counter.
+ * @param gas_refunds The amount of gas to be refunded.
+ * @param stack       The stack used for execution.
+ * @param stack_size  The number of items on the stack.
+ * @param memory      The memory used for execution.
+ * @param memory_size The size of the memory.
+ * @param steps       The number of steps to execute.
+ * @return            The step result.
+ */
+typedef struct evmc_step_result (*evmc_step_n_fn)(struct evmc_vm_steppable* vm,
+                                                  const struct evmc_host_interface* host,
+                                                  struct evmc_host_context* context,
+                                                  enum evmc_revision rev,
+                                                  const struct evmc_message* msg,
+                                                  const evmc_bytes32* code_hash,
+                                                  uint8_t const* code,
+                                                  size_t code_size,
+                                                  enum evmc_step_status_code status,
+                                                  uint64_t pc,
+                                                  int64_t gas_refunds,
+                                                  evmc_uint256be* stack,
+                                                  size_t stack_size,
+                                                  uint8_t* memory,
+                                                  size_t memory_size,
+                                                  int32_t steps);
+
+/**
+ * Destroys the VM instance.
+ *
+ * @param vm  The VM instance to be destroyed.
+ */
+typedef void (*evmc_destroy_steppable_fn)(struct evmc_vm_steppable* vm);
+
+
+/**
+ * The testable VM instance.
+ *
+ * Defines the base struct of the testable VM implementation.
+ */
+struct evmc_vm_steppable
+{
+    /**
+     * EVMC VM instance.
+     *
+     * The base struct of the VM implementation.
+     */
+    struct evmc_vm* vm;
+
+    /**
+     * Pointer to function executing a code by the VM instance for N steps.
+     *
+     * This is a mandatory method and MUST NOT be set to NULL.
+     */
+    evmc_step_n_fn step_n;
+
+    /**
+     * Pointer to function destroying the VM instance.
+     *
+     * This is a mandatory method and MUST NOT be set to NULL.
+     */
+    evmc_destroy_steppable_fn destroy;
 };
 
 /* END Python CFFI declarations */

--- a/include/evmc/helpers.h
+++ b/include/evmc/helpers.h
@@ -306,6 +306,55 @@ static inline const char* evmc_revision_to_string(enum evmc_revision rev)
     return "<unknown>";
 }
 
+/**
+ * Releases the resources allocated to the step result.
+ *
+ * @param result  The result object to be released. MUST NOT be NULL.
+ *
+ * @see evmc_step_result::release() evmc_release_step_result_fn
+ */
+static inline void evmc_release_step_result(struct evmc_step_result* result)
+{
+    if (result->release)
+        result->release(result);
+}
+
+/**
+ * Destroys the VM instance.
+ *
+ * @see evmc_destroy_fn
+ */
+static inline void evmc_destroy_steppable(struct evmc_vm_steppable* vm)
+{
+    vm->destroy(vm);
+}
+
+/**
+ * Steps N steps through the code in the VM instance.
+ *
+ * @see evmc_step_n_fn.
+ */
+static inline struct evmc_step_result evmc_step_n(struct evmc_vm_steppable* vm,
+                                                  const struct evmc_host_interface* host,
+                                                  struct evmc_host_context* context,
+                                                  enum evmc_revision rev,
+                                                  const struct evmc_message* msg,
+                                                  const evmc_bytes32* code_hash,
+                                                  uint8_t const* code,
+                                                  size_t code_size,
+                                                  enum evmc_step_status_code status,
+                                                  uint64_t pc,
+                                                  int64_t gas_refunds,
+                                                  evmc_uint256be* stack,
+                                                  size_t stack_size,
+                                                  uint8_t* memory,
+                                                  size_t memory_size,
+                                                  int32_t steps)
+{
+    return vm->step_n(vm, host, context, rev, msg, code_hash, code, code_size, status, pc,
+                      gas_refunds, stack, stack_size, memory, memory_size, steps);
+}
+
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR adds a new interface to `evmc` that allows stepping through an interpreter.