### PR TITLE
Extend step-n interface and stepParameters with output buffer

### DIFF
--- a/bindings/go/evmc/evmc.go
+++ b/bindings/go/evmc/evmc.go
@@ -72,9 +72,9 @@ static struct evmc_step_result step_n_wrapper(struct evmc_vm_steppable* vm,
                                               size_t stack_size,
                                               uint8_t* memory,
                                               size_t memory_size,
-                                              int32_t steps,
-                                              uint8_t* output_data,
-                                              size_t output_size)
+                                              uint8_t* last_call_result_data ,
+                                              size_t last_call_result_data_size,
+                                              int32_t steps)
 {
     struct evmc_message msg = {
         kind,    flags,      depth,      gas,    *recipient,
@@ -84,7 +84,7 @@ static struct evmc_step_result step_n_wrapper(struct evmc_vm_steppable* vm,
 
     struct evmc_host_context* context = (struct evmc_host_context*)context_index;
     return evmc_step_n(vm, &evmc_go_host, context, rev, &msg, code_hash, code, code_size, status,
-                       pc, gas_refunds, stack, stack_size, memory, memory_size, steps, output_data, output_size);
+                       pc, gas_refunds, stack, stack_size, memory, memory_size, last_call_result_data, last_call_result_data_size, steps);
 }
 */
 import "C"
@@ -349,7 +349,7 @@ type StepParameters struct {
 	Recipient      Address
 	Sender         Address
 	Input          []byte
-	Output         []byte
+	LastCallResult []byte
 	Value          Hash
 	CodeHash       *Hash
 	Code           []byte
@@ -422,9 +422,9 @@ func (vm *VMSteppable) StepN(params StepParameters) (res StepResult, err error) 
 		C.size_t(len(params.Stack)/32),
 		memory,
 		C.size_t(len(params.Memory)),
-		C.int32_t(params.NumSteps),
-		bytesPtr(params.Output),
-		C.size_t(len(params.Output)))
+		bytesPtr(params.LastCallResult),
+		C.size_t(len(params.LastCallResult)),
+		C.int32_t(params.NumSteps))
 
 	removeHostContext(ctxId)
 

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -1293,6 +1293,8 @@ struct evmc_vm_steppable;
  * @param memory      The memory used for execution.
  * @param memory_size The size of the memory.
  * @param steps       The number of steps to execute.
+ * @param output_data The reference to output data.
+ * @param output_size The size of output data.
  * @return            The step result.
  */
 typedef struct evmc_step_result (*evmc_step_n_fn)(struct evmc_vm_steppable* vm,
@@ -1310,7 +1312,9 @@ typedef struct evmc_step_result (*evmc_step_n_fn)(struct evmc_vm_steppable* vm,
                                                   size_t stack_size,
                                                   uint8_t* memory,
                                                   size_t memory_size,
-                                                  int32_t steps);
+                                                  int32_t steps,
+                                                  uint8_t* output_data,
+                                                  size_t output_size);
 
 /**
  * Destroys the VM instance.

--- a/include/evmc/evmc.h
+++ b/include/evmc/evmc.h
@@ -1293,8 +1293,8 @@ struct evmc_vm_steppable;
  * @param memory      The memory used for execution.
  * @param memory_size The size of the memory.
  * @param steps       The number of steps to execute.
- * @param output_data The reference to output data.
- * @param output_size The size of output data.
+ * @param last_call_result_data The reference to output data.
+ * @param last_call_result_data_size  The size of output data.
  * @return            The step result.
  */
 typedef struct evmc_step_result (*evmc_step_n_fn)(struct evmc_vm_steppable* vm,
@@ -1312,9 +1312,9 @@ typedef struct evmc_step_result (*evmc_step_n_fn)(struct evmc_vm_steppable* vm,
                                                   size_t stack_size,
                                                   uint8_t* memory,
                                                   size_t memory_size,
-                                                  int32_t steps,
-                                                  uint8_t* output_data,
-                                                  size_t output_size);
+                                                  uint8_t* last_call_result_data,
+                                                  size_t last_call_result_data_size,
+                                                  int32_t steps);
 
 /**
  * Destroys the VM instance.

--- a/include/evmc/helpers.h
+++ b/include/evmc/helpers.h
@@ -349,13 +349,13 @@ static inline struct evmc_step_result evmc_step_n(struct evmc_vm_steppable* vm,
                                                   size_t stack_size,
                                                   uint8_t* memory,
                                                   size_t memory_size,
-                                                  int32_t steps,
-                                                  uint8_t* output_data,
-                                                  size_t output_size)
+                                                  uint8_t* last_call_result_data,
+                                                  size_t last_call_result_data_size,
+                                                  int32_t steps)
 {
     return vm->step_n(vm, host, context, rev, msg, code_hash, code, code_size, status, pc,
-                      gas_refunds, stack, stack_size, memory, memory_size, steps, output_data,
-                      output_size);
+                      gas_refunds, stack, stack_size, memory, memory_size, last_call_result_data,
+                      last_call_result_data_size, steps);
 }
 
 /** @} */

--- a/include/evmc/helpers.h
+++ b/include/evmc/helpers.h
@@ -349,10 +349,13 @@ static inline struct evmc_step_result evmc_step_n(struct evmc_vm_steppable* vm,
                                                   size_t stack_size,
                                                   uint8_t* memory,
                                                   size_t memory_size,
-                                                  int32_t steps)
+                                                  int32_t steps,
+                                                  uint8_t* output_data,
+                                                  size_t output_size)
 {
     return vm->step_n(vm, host, context, rev, msg, code_hash, code, code_size, status, pc,
-                      gas_refunds, stack, stack_size, memory, memory_size, steps);
+                      gas_refunds, stack, stack_size, memory, memory_size, steps, output_data,
+                      output_size);
 }
 
 /** @} */


### PR DESCRIPTION
This PR extends the interface of `step-n` to accept a pre-existing value of `ouput`